### PR TITLE
SM-5 Deterministic transition ordering

### DIFF
--- a/src/main/java/alex/band/statemachine/ListenableStateMachine.java
+++ b/src/main/java/alex/band/statemachine/ListenableStateMachine.java
@@ -1,6 +1,6 @@
 package alex.band.statemachine;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import alex.band.statemachine.listener.StateMachineListener;
@@ -16,7 +16,7 @@ import alex.band.statemachine.state.State;
  */
 public abstract class ListenableStateMachine<S, E> implements StateMachine<S, E> {
 
-	private Set<StateMachineListener<S, E>> listeners = new HashSet<>();
+	private Set<StateMachineListener<S, E>> listeners = new LinkedHashSet<>();
 
 
 	@Override

--- a/src/main/java/alex/band/statemachine/builder/impl/StartStopActionsConfigurerImpl.java
+++ b/src/main/java/alex/band/statemachine/builder/impl/StartStopActionsConfigurerImpl.java
@@ -1,7 +1,7 @@
 package alex.band.statemachine.builder.impl;
 
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import alex.band.statemachine.StateMachineStartAction;
@@ -15,8 +15,8 @@ import alex.band.statemachine.builder.StartStopActionsConfigurer;
  */
 public class StartStopActionsConfigurerImpl<S, E> implements StartStopActionsConfigurer<S, E> {
 
-	private Set<StateMachineStartAction<S, E>> startActions = new HashSet<>();
-	private Set<StateMachineStopAction<S, E>> stopActions = new HashSet<>();
+	private Set<StateMachineStartAction<S, E>> startActions = new LinkedHashSet<>();
+	private Set<StateMachineStopAction<S, E>> stopActions = new LinkedHashSet<>();
 
 	@Override
 	public StartStopActionsConfigurer<S, E> onStart(StateMachineStartAction<S, E>... actions) {

--- a/src/main/java/alex/band/statemachine/builder/impl/StateMachineBuilderImpl.java
+++ b/src/main/java/alex/band/statemachine/builder/impl/StateMachineBuilderImpl.java
@@ -1,7 +1,7 @@
 package alex.band.statemachine.builder.impl;
 
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -44,8 +44,8 @@ public class StateMachineBuilderImpl<S, E> implements StateMachineBuilder<S, E> 
 	private State<S, E> finalState;
 	private Map<S, State<S, E>> states = new HashMap<>();
 	private Map<S, Set<Transition<S, E>>> transitions = new HashMap<>();
-	private Set<StateMachineStartAction<S, E>> startActions = new HashSet<>();
-	private Set<StateMachineStopAction<S, E>> stopActions = new HashSet<>();
+	private Set<StateMachineStartAction<S, E>> startActions = new LinkedHashSet<>();
+	private Set<StateMachineStopAction<S, E>> stopActions = new LinkedHashSet<>();
 
 	@Override
 	public StartStopActionsConfigurer defineStartStopActions() {
@@ -110,7 +110,7 @@ public class StateMachineBuilderImpl<S, E> implements StateMachineBuilder<S, E> 
 	}
 
 	private Set<S> validateAndGetTargetStatesFromTransitions() {
-		Set<S> targetStates = new HashSet<>();
+		Set<S> targetStates = new LinkedHashSet<>();
 		for (Set<Transition<S, E>> transitionsBySource: transitions.values()) {
 			for (Transition<S, E> transition: transitionsBySource) {
 
@@ -129,8 +129,8 @@ public class StateMachineBuilderImpl<S, E> implements StateMachineBuilder<S, E> 
 	}
 
 	private void validateTopology() {
-		Set<S> enteredStates = new HashSet<>(states.keySet());
-		Set<S> exitedStates = new HashSet<>(states.keySet());
+		Set<S> enteredStates = new LinkedHashSet<>(states.keySet());
+		Set<S> exitedStates = new LinkedHashSet<>(states.keySet());
 		enteredStates.remove(initialState.getId());
 		exitedStates.remove(finalState.getId());
 
@@ -145,7 +145,7 @@ public class StateMachineBuilderImpl<S, E> implements StateMachineBuilder<S, E> 
 	}
 
 	private Set<S> difference(Set<S> set1, Set<S> set2) {
-		Set<S> result = new HashSet<>(set1);
+		Set<S> result = new LinkedHashSet<>(set1);
 		result.removeAll(set2);
 		return result;
 	}
@@ -183,7 +183,7 @@ public class StateMachineBuilderImpl<S, E> implements StateMachineBuilder<S, E> 
 
 	private void addTransition(S sourceState, Transition<S, E> transition) {
 		if (!transitions.containsKey(sourceState)) {
-			transitions.put(sourceState, new HashSet<Transition<S, E>>());
+			transitions.put(sourceState, new LinkedHashSet<Transition<S, E>>());
 		}
 		transitions.get(sourceState).add(transition);
 	}

--- a/src/main/java/alex/band/statemachine/state/StateImpl.java
+++ b/src/main/java/alex/band/statemachine/state/StateImpl.java
@@ -1,7 +1,7 @@
 package alex.band.statemachine.state;
 
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -18,9 +18,9 @@ import alex.band.statemachine.transition.Transition;
 public class StateImpl<S, E> implements State<S, E> {
 
 	private S stateId;
-	private Set<StateAction<S, E>> actions = new HashSet<>();
+	private Set<StateAction<S, E>> actions = new LinkedHashSet<>();
 	private Map<E, Set<Transition<S, E>>> transitions = new HashMap<>();
-	private Set<E> deferredEvents = new HashSet<>();
+	private Set<E> deferredEvents = new LinkedHashSet<>();
 
 	public StateImpl(S stateId) {
 		this.stateId = stateId;
@@ -80,7 +80,7 @@ public class StateImpl<S, E> implements State<S, E> {
 
 	public void addTransition(Transition<S, E> transition) {
 		if (!transitions.containsKey(transition.getEvent())) {
-			transitions.put(transition.getEvent(), new HashSet<Transition<S, E>>());
+			transitions.put(transition.getEvent(), new LinkedHashSet<Transition<S, E>>());
 		}
 		transitions.get(transition.getEvent()).add(transition);
 	}

--- a/src/main/java/alex/band/statemachine/transition/TransitionImpl.java
+++ b/src/main/java/alex/band/statemachine/transition/TransitionImpl.java
@@ -1,7 +1,7 @@
 package alex.band.statemachine.transition;
 
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -18,7 +18,7 @@ public class TransitionImpl<S, E> implements Transition<S, E> {
 	private S target;
 	private E event;
 	private Guard<S, E> guard;
-	private Set<TransitionAction<S, E>> actions = new HashSet<>();
+	private Set<TransitionAction<S, E>> actions = new LinkedHashSet<>();
 
 	@Override
 	public S getSource() {

--- a/src/test/java/alex/band/statemachine/builder/impl/StateMachineDeterministicTransitionTest.java
+++ b/src/test/java/alex/band/statemachine/builder/impl/StateMachineDeterministicTransitionTest.java
@@ -1,0 +1,152 @@
+package alex.band.statemachine.builder.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import alex.band.statemachine.StateMachineDetails;
+import alex.band.statemachine.builder.StateMachineBuilder;
+import alex.band.statemachine.message.StateMachineMessage;
+import alex.band.statemachine.transition.Guard;
+
+/**
+ * Tests for deterministic transition ordering.
+ * When multiple transitions share the same event and their guards can evaluate to true,
+ * the first defined transition should always win.
+ *
+ * @author Aliaksandr Bandarchyk
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class StateMachineDeterministicTransitionTest {
+
+	private static final String S1 = "S1";
+	private static final String S2 = "S2";
+	private static final String S3 = "S3";
+	private static final String FINAL = "FINAL";
+	private static final String SHARED_EVENT = "SHARED_EVENT";
+
+	private StateMachineImpl<String, String> stateMachine;
+
+	@Mock
+	private Guard<String, String> alwaysTrueGuard1;
+	@Mock
+	private Guard<String, String> alwaysTrueGuard2;
+
+	@BeforeEach
+	@SuppressWarnings("unchecked")
+	void setUp() {
+		when(alwaysTrueGuard1.evaluate(isA(StateMachineMessage.class), isA(StateMachineDetails.class))).thenReturn(true);
+		when(alwaysTrueGuard2.evaluate(isA(StateMachineMessage.class), isA(StateMachineDetails.class))).thenReturn(true);
+	}
+
+	/**
+	 * Verifies that when multiple transitions are defined for the same event
+	 * and both guards evaluate to true, the first defined transition wins.
+	 */
+	@Test
+	void deterministicTransition_firstDefinedTransitionWins() {
+		StateMachineBuilder<String, String> builder = new StateMachineBuilderImpl<>();
+
+		builder.defineState(S1).asInitial();
+		builder.defineState(S2);
+		builder.defineState(S3);
+		builder.defineState(FINAL).asFinal();
+
+		// First transition: S1 -> S2 with always-true guard
+		builder.defineExternalTransitionFor(S1).to(S2).by(SHARED_EVENT).guardedBy(alwaysTrueGuard1);
+		// Second transition: S1 -> S3 with always-true guard (same event)
+		builder.defineExternalTransitionFor(S1).to(S3).by(SHARED_EVENT).guardedBy(alwaysTrueGuard2);
+
+		builder.defineExternalTransitionFor(S2).to(FINAL).by("FINISH");
+		builder.defineExternalTransitionFor(S3).to(FINAL).by("FINISH");
+
+		stateMachine = (StateMachineImpl<String, String>) builder.build();
+		stateMachine.start();
+
+		assertEquals(S1, stateMachine.getCurrentState().getId());
+
+		// Both guards return true, but first transition (S1 -> S2) should win
+		stateMachine.accept(SHARED_EVENT);
+
+		assertEquals(S2, stateMachine.getCurrentState().getId());
+	}
+
+	/**
+	 * Verifies that reversing the order of transition definition changes which one wins.
+	 */
+	@Test
+	void deterministicTransition_orderMatters_whenReversed() {
+		StateMachineBuilder<String, String> builder = new StateMachineBuilderImpl<>();
+
+		builder.defineState(S1).asInitial();
+		builder.defineState(S2);
+		builder.defineState(S3);
+		builder.defineState(FINAL).asFinal();
+
+		// First transition: S1 -> S3 with always-true guard (reversed order)
+		builder.defineExternalTransitionFor(S1).to(S3).by(SHARED_EVENT).guardedBy(alwaysTrueGuard2);
+		// Second transition: S1 -> S2 with always-true guard
+		builder.defineExternalTransitionFor(S1).to(S2).by(SHARED_EVENT).guardedBy(alwaysTrueGuard1);
+
+		builder.defineExternalTransitionFor(S2).to(FINAL).by("FINISH");
+		builder.defineExternalTransitionFor(S3).to(FINAL).by("FINISH");
+
+		stateMachine = (StateMachineImpl<String, String>) builder.build();
+		stateMachine.start();
+
+		assertEquals(S1, stateMachine.getCurrentState().getId());
+
+		// Now S1 -> S3 should win because it was defined first
+		stateMachine.accept(SHARED_EVENT);
+
+		assertEquals(S3, stateMachine.getCurrentState().getId());
+	}
+
+	/**
+	 * Verifies that when only the second transition's guard matches, it is selected.
+	 */
+	@Test
+	void deterministicTransition_secondTransitionWins_whenFirstGuardFails() {
+		Guard<String, String> falseGuard = new Guard<>() {
+			@Override
+			public boolean evaluate(StateMachineMessage<String> message, StateMachineDetails<String, String> context) {
+				return false;
+			}
+		};
+
+		StateMachineBuilder<String, String> builder = new StateMachineBuilderImpl<>();
+
+		builder.defineState(S1).asInitial();
+		builder.defineState(S2);
+		builder.defineState(S3);
+		builder.defineState(FINAL).asFinal();
+
+		// First transition: guard always returns false
+		builder.defineExternalTransitionFor(S1).to(S2).by(SHARED_EVENT).guardedBy(falseGuard);
+		// Second transition: guard always returns true
+		builder.defineExternalTransitionFor(S1).to(S3).by(SHARED_EVENT).guardedBy(alwaysTrueGuard1);
+
+		builder.defineExternalTransitionFor(S2).to(FINAL).by("FINISH");
+		builder.defineExternalTransitionFor(S3).to(FINAL).by("FINISH");
+
+		stateMachine = (StateMachineImpl<String, String>) builder.build();
+		stateMachine.start();
+
+		assertEquals(S1, stateMachine.getCurrentState().getId());
+
+		// First guard fails, second should win
+		stateMachine.accept(SHARED_EVENT);
+
+		assertEquals(S3, stateMachine.getCurrentState().getId());
+	}
+
+}


### PR DESCRIPTION
Replace HashSet with LinkedHashSet in all collections to preserve insertion order:
- StateImpl: transitions, actions, deferredEvents
- StateMachineBuilderImpl: startActions, stopActions, transitions
- TransitionImpl: actions
- StartStopActionsConfigurerImpl: startActions, stopActions
- ListenableStateMachine: listeners

Add StateMachineDeterministicTransitionTest with 3 tests verifying that first defined transition wins when multiple guards evaluate to true