### PR TITLE
SM-7 refactor: extract listener notification methods and add onEventDeferr…

### DIFF
--- a/src/main/java/alex/band/statemachine/ListenableStateMachine.java
+++ b/src/main/java/alex/band/statemachine/ListenableStateMachine.java
@@ -54,26 +54,48 @@ public abstract class ListenableStateMachine<S, E> implements StateMachine<S, E>
 
 	@Override
 	public boolean accept(StateMachineMessage<E> message) {
-		State<S, E> previousState = getCurrentState();
-		boolean messageAccepted = doAccept(message);
-
-		for (StateMachineListener<S, E> listener: listeners) {
-
-			if (messageAccepted) {
-				listener.onStateChanged(message, previousState, this);
-
-			} else {
-				listener.onEventNotAccepted(message, this);
-			}
-		}
-
-		return messageAccepted;
+		return doAccept(message);
 	}
 
 	/**
 	 * Actions to process messages by the state machine.
 	 */
 	protected abstract boolean doAccept(StateMachineMessage<E> message);
+
+	/**
+	 * Notifies all registered listeners that the state has changed.
+	 *
+	 * @param message the message that caused the state change
+	 * @param previousState the state before the change
+	 */
+	protected void notifyStateChanged(StateMachineMessage<E> message, State<S, E> previousState) {
+		for (StateMachineListener<S, E> listener: listeners) {
+			listener.onStateChanged(message, previousState, this);
+		}
+	}
+
+	/**
+	 * Notifies all registered listeners that an event has been deferred.
+	 *
+	 * @param message the deferred message
+	 * @param currentState the current state that deferred the event
+	 */
+	protected void notifyEventDeferred(StateMachineMessage<E> message, State<S, E> currentState) {
+		for (StateMachineListener<S, E> listener: listeners) {
+			listener.onEventDeferred(message, currentState, this);
+		}
+	}
+
+	/**
+	 * Notifies all registered listeners that an event was not accepted.
+	 *
+	 * @param message the message that was not accepted
+	 */
+	protected void notifyEventNotAccepted(StateMachineMessage<E> message) {
+		for (StateMachineListener<S, E> listener: listeners) {
+			listener.onEventNotAccepted(message, this);
+		}
+	}
 
 	@Override
 	public void addListener(StateMachineListener<S, E> listener) {

--- a/src/main/java/alex/band/statemachine/builder/impl/StateMachineImpl.java
+++ b/src/main/java/alex/band/statemachine/builder/impl/StateMachineImpl.java
@@ -85,11 +85,13 @@ public class StateMachineImpl<S, E> extends ListenableStateMachine<S, E> {
 		checkState(running, "Statemachine is not running yet.");
 
 		if (message == null) {
+			notifyEventNotAccepted(message);
 			return false;
 		}
 
 		if (currentState.canBeDeferred(message)) {
 			deferredQueue.offer(message);
+			notifyEventDeferred(message, currentState);
 			return true;
 		}
 
@@ -119,10 +121,11 @@ public class StateMachineImpl<S, E> extends ListenableStateMachine<S, E> {
 
 			doCurrentStateExit(transition);
 			executeTransitionActions(message, transition.get().getActions());
-			doNewStateEnter(transition);
+			doNewStateEnter(transition, message);
 			return true;
 		}
 
+		notifyEventNotAccepted(message);
 		return false;
 	}
 
@@ -138,10 +141,12 @@ public class StateMachineImpl<S, E> extends ListenableStateMachine<S, E> {
 		}
 	}
 
-	private void doNewStateEnter(Optional<Transition<S, E>> transition) {
+	private void doNewStateEnter(Optional<Transition<S, E>> transition, StateMachineMessage<E> message) {
 		if (transition.get().isExternal()) {
+			State<S, E> previousState = currentState;
 			currentState = states.get(transition.get().getTarget().get());
 			currentState.onEnter(this);
+			notifyStateChanged(message, previousState);
 		}
 		if (finalState.equals(currentState)) {
 			stop();

--- a/src/main/java/alex/band/statemachine/listener/StateMachineListener.java
+++ b/src/main/java/alex/band/statemachine/listener/StateMachineListener.java
@@ -51,4 +51,20 @@ public interface StateMachineListener<S, E> {
 	 */
 	void onEventNotAccepted(StateMachineMessage<E> message, StateMachineDetails<S, E> stateMachineDetails);
 
+	/**
+	 * Called when an incoming {@link StateMachineMessage} is accepted but deferred for later processing
+	 * because the current state is not ready to handle it.
+	 *
+	 * <p>The deferred event will be stored in the queue and automatically processed when the state machine
+	 * transitions to a state that can handle it.
+	 *
+	 * <p>The listener receives information about the {@link StateMachineMessage} that was deferred,
+	 * the current {@link State}, and the state machine details via the {@link StateMachineDetails} interface.
+	 *
+	 * @param message the deferred message
+	 * @param currentState the current state that deferred the event
+	 * @param stateMachineDetails the state machine details
+	 */
+	void onEventDeferred(StateMachineMessage<E> message, State<S, E> currentState, StateMachineDetails<S, E> stateMachineDetails);
+
 }

--- a/src/main/java/alex/band/statemachine/listener/StateMachineListenerAdapter.java
+++ b/src/main/java/alex/band/statemachine/listener/StateMachineListenerAdapter.java
@@ -31,4 +31,9 @@ public abstract class StateMachineListenerAdapter<S, E> implements StateMachineL
 		// do nothing by default
 	}
 
+	@Override
+	public void onEventDeferred(StateMachineMessage<E> message, State<S, E> currentState, StateMachineDetails<S, E> stateMachineDetails) {
+		// do nothing by default
+	}
+
 }

--- a/src/test/java/alex/band/statemachine/builder/impl/StateMachineListenerNotificationTest.java
+++ b/src/test/java/alex/band/statemachine/builder/impl/StateMachineListenerNotificationTest.java
@@ -1,0 +1,215 @@
+package alex.band.statemachine.builder.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import alex.band.statemachine.builder.StateMachineBuilder;
+import alex.band.statemachine.listener.StateMachineListenerAdapter;
+import alex.band.statemachine.message.StateMachineMessage;
+import alex.band.statemachine.message.StateMachineMessageImpl;
+import alex.band.statemachine.state.State;
+
+class StateMachineListenerNotificationTest {
+
+	private static final String READY = "Ready";
+	private static final String PROCESSING = "Processing";
+	private static final String STOPPED = "Stopped";
+	private static final String START = "Start";
+	private static final String STOP = "Stop";
+	private static final String DEFERRED_EVENT = "Deferred";
+
+	@Test
+	void listener_onStateChangedCalledOnlyForExternalTransitions() {
+		StateMachineBuilder<String, String> builder = new StateMachineBuilderImpl<>();
+
+		builder.defineState(READY).asInitial();
+		builder.defineState(PROCESSING);
+		builder.defineState(STOPPED).asFinal();
+
+		builder.defineExternalTransitionFor(READY).to(PROCESSING).by(START);
+		builder.defineExternalTransitionFor(PROCESSING).to(STOPPED).by(STOP);
+
+		StateMachineImpl<String, String> sm = (StateMachineImpl<String, String>) builder.build();
+
+		TrackingListener<String, String> listener = new TrackingListener<>();
+		sm.addListener(listener);
+
+		sm.start();
+		assertEquals(READY, sm.getCurrentState().getId());
+		assertEquals(0, listener.stateChangedCount());
+
+		sm.accept(START);
+		assertEquals(1, listener.stateChangedCount());
+		assertEquals(READY, listener.getLastPreviousState().getId());
+		assertEquals(PROCESSING, sm.getCurrentState().getId());
+
+		sm.accept(STOP);
+		assertEquals(2, listener.stateChangedCount());
+		assertEquals(PROCESSING, listener.getLastPreviousState().getId());
+		assertEquals(STOPPED, sm.getCurrentState().getId());
+	}
+
+	@Test
+	void listener_onStateChangedNotCalledForInternalTransitions() {
+		StateMachineBuilder<String, String> builder = new StateMachineBuilderImpl<>();
+
+		builder.defineState(READY).asInitial();
+		builder.defineState(STOPPED).asFinal();
+
+		builder.defineExternalTransitionFor(READY).to(STOPPED).by(STOP);
+		builder.defineInternalTransitionFor(READY).by(START);
+
+		StateMachineImpl<String, String> sm = (StateMachineImpl<String, String>) builder.build();
+
+		TrackingListener<String, String> listener = new TrackingListener<>();
+		sm.addListener(listener);
+
+		sm.start();
+		assertEquals(0, listener.stateChangedCount());
+
+		// Internal transition does not change state
+		sm.accept(START);
+		assertEquals(0, listener.stateChangedCount());
+		assertEquals(READY, sm.getCurrentState().getId());
+
+		// External transition changes state
+		sm.accept(STOP);
+		assertEquals(1, listener.stateChangedCount());
+		assertEquals(READY, listener.getLastPreviousState().getId());
+		assertEquals(STOPPED, sm.getCurrentState().getId());
+	}
+
+	@Test
+	void listener_onEventDeferredCalledForDeferredEvents() {
+		StateMachineBuilder<String, String> builder = new StateMachineBuilderImpl<>();
+
+		builder.defineState(READY).asInitial().withDeferredEvent(DEFERRED_EVENT);
+		builder.defineState(PROCESSING);
+		builder.defineState(STOPPED).asFinal();
+
+		builder.defineExternalTransitionFor(READY).to(PROCESSING).by(START);
+		builder.defineExternalTransitionFor(PROCESSING).to(STOPPED).by(DEFERRED_EVENT);
+
+		StateMachineImpl<String, String> sm = (StateMachineImpl<String, String>) builder.build();
+
+		TrackingListener<String, String> listener = new TrackingListener<>();
+		sm.addListener(listener);
+
+		sm.start();
+
+		// Deferred event — state does not change
+		sm.accept(new StateMachineMessageImpl<>(DEFERRED_EVENT));
+		assertEquals(0, listener.stateChangedCount());
+		assertEquals(1, listener.deferredCount());
+		assertEquals(READY, listener.getLastDeferredState().getId());
+		assertEquals(READY, sm.getCurrentState().getId());
+
+		// Trigger transition — deferred event processed automatically
+		sm.accept(START);
+		assertEquals(2, listener.stateChangedCount()); // READY->PROCESSING + PROCESSING->STOPPED (deferred)
+		assertEquals(STOPPED, sm.getCurrentState().getId());
+	}
+
+	@Test
+	void listener_onEventNotAcceptedCalledWhenNoTransitionMatches() {
+		StateMachineBuilder<String, String> builder = new StateMachineBuilderImpl<>();
+
+		builder.defineState(READY).asInitial();
+		builder.defineState(STOPPED).asFinal();
+
+		builder.defineExternalTransitionFor(READY).to(STOPPED).by(STOP);
+
+		StateMachineImpl<String, String> sm = (StateMachineImpl<String, String>) builder.build();
+
+		TrackingListener<String, String> listener = new TrackingListener<>();
+		sm.addListener(listener);
+
+		sm.start();
+
+		// Unknown event — no transition matches
+		boolean result = sm.accept(new StateMachineMessageImpl<>("Unknown"));
+		assertFalse(result);
+		assertEquals(0, listener.stateChangedCount());
+		assertEquals(1, listener.notAcceptedCount());
+	}
+
+	@Test
+	void listener_eachDeferredMessageTriggersStateChangeNotification() {
+		StateMachineBuilder<String, String> builder = new StateMachineBuilderImpl<>();
+
+		builder.defineState(READY).asInitial().withDeferredEvents(Set.of("E1", "E2"));
+		builder.defineState(S1).withDeferredEvent("E2");
+		builder.defineState(S2);
+		builder.defineState(S3).asFinal();
+
+		builder.defineExternalTransitionFor(READY).to(S1).by("Go");
+		builder.defineExternalTransitionFor(S1).to(S2).by("E1");
+		builder.defineExternalTransitionFor(S2).to(S3).by("E2");
+
+		StateMachineImpl<String, String> sm = (StateMachineImpl<String, String>) builder.build();
+
+		TrackingListener<String, String> listener = new TrackingListener<>();
+		sm.addListener(listener);
+
+		sm.start();
+
+		// Defer two events
+		sm.accept(new StateMachineMessageImpl<>("E1"));
+		sm.accept(new StateMachineMessageImpl<>("E2"));
+		assertEquals(0, listener.stateChangedCount());
+		assertEquals(2, listener.deferredCount());
+
+		// "Go" triggers READY->S1, then E1 is processed S1->S2, then E2 is processed S2->S3
+		sm.accept("Go");
+
+		// Three state changes: READY->S1, S1->S2, S2->S3
+		assertEquals(3, listener.stateChangedCount());
+		assertEquals(S3, sm.getCurrentState().getId());
+	}
+
+	private static final String S1 = "S1";
+	private static final String S2 = "S2";
+	private static final String S3 = "S3";
+
+	private static class TrackingListener<S, E> extends StateMachineListenerAdapter<S, E> {
+		private int stateChangedCount = 0;
+		private int deferredCount = 0;
+		private int notAcceptedCount = 0;
+		private State<S, E> lastPreviousState;
+		private State<S, E> lastDeferredState;
+		private List<StateMachineMessage<E>> deferredMessages = new ArrayList<>();
+		private List<StateMachineMessage<E>> notAcceptedMessages = new ArrayList<>();
+
+		@Override
+		public void onStateChanged(StateMachineMessage<E> message, State<S, E> previousState, alex.band.statemachine.StateMachineDetails<S, E> stateMachineDetails) {
+			stateChangedCount++;
+			lastPreviousState = previousState;
+		}
+
+		@Override
+		public void onEventDeferred(StateMachineMessage<E> message, State<S, E> currentState, alex.band.statemachine.StateMachineDetails<S, E> stateMachineDetails) {
+			deferredCount++;
+			lastDeferredState = currentState;
+			deferredMessages.add(message);
+		}
+
+		@Override
+		public void onEventNotAccepted(StateMachineMessage<E> message, alex.band.statemachine.StateMachineDetails<S, E> stateMachineDetails) {
+			notAcceptedCount++;
+			notAcceptedMessages.add(message);
+		}
+
+		int stateChangedCount() { return stateChangedCount; }
+		int deferredCount() { return deferredCount; }
+		int notAcceptedCount() { return notAcceptedCount; }
+		State<S, E> getLastPreviousState() { return lastPreviousState; }
+		State<S, E> getLastDeferredState() { return lastDeferredState; }
+	}
+
+}


### PR DESCRIPTION
…ed callback

- Extract notifyStateChanged, notifyEventDeferred, notifyEventNotAccepted from ListenableStateMachine.accept() into separate protected methods
- Add onEventDeferred callback to StateMachineListener interface for tracking deferred events with queue storage
- Add default no-op implementation in StateMachineListenerAdapter
- Move listener notifications to StateMachineImpl.doAccept() to cover null messages, deferred events, and unaccepted events
- Fix stateChanged notification to fire only on external transitions (after currentState is updated, not before)
- Add StateMachineListenerNotificationTest with 3 test cases covering state change, internal transition, and event deferral scenarios