### PR TITLE
feat: add sync FSM with async actions and thread safety

### DIFF
--- a/src/main/java/alex/band/statemachine/ListenableStateMachine.java
+++ b/src/main/java/alex/band/statemachine/ListenableStateMachine.java
@@ -20,7 +20,7 @@ public abstract class ListenableStateMachine<S, E> implements StateMachine<S, E>
 
 
 	@Override
-	public void start() {
+	public synchronized void start() {
 		doStart();
 
 		for (StateMachineListener<S, E> listener: listeners) {
@@ -34,7 +34,7 @@ public abstract class ListenableStateMachine<S, E> implements StateMachine<S, E>
 	protected abstract void doStart();
 
 	@Override
-	public void stop() {
+	public synchronized void stop() {
 		doStop();
 
 		for (StateMachineListener<S, E> listener: listeners) {
@@ -98,12 +98,12 @@ public abstract class ListenableStateMachine<S, E> implements StateMachine<S, E>
 	}
 
 	@Override
-	public void addListener(StateMachineListener<S, E> listener) {
+	public synchronized void addListener(StateMachineListener<S, E> listener) {
 		listeners.add(listener);
 	}
 
 	@Override
-	public void removeListener(StateMachineListener<S, E> listener) {
+	public synchronized void removeListener(StateMachineListener<S, E> listener) {
 		listeners.remove(listener);
 	}
 

--- a/src/main/java/alex/band/statemachine/builder/ExternalTransitionConfigurer.java
+++ b/src/main/java/alex/band/statemachine/builder/ExternalTransitionConfigurer.java
@@ -2,6 +2,7 @@ package alex.band.statemachine.builder;
 
 import java.util.Set;
 
+import alex.band.statemachine.transition.AsyncAction;
 import alex.band.statemachine.transition.Guard;
 import alex.band.statemachine.transition.TransitionAction;
 
@@ -39,5 +40,15 @@ public interface ExternalTransitionConfigurer<S, E> {
 	 * Sets a set of {@link TransitionAction}s to be executed during the transition.
 	 */
 	ExternalTransitionConfigurer<S, E> withActions(Set<TransitionAction<S, E>> actions);
+
+	/**
+	 * Sets an {@link AsyncAction} to be executed asynchronously after the transition completes.
+	 */
+	ExternalTransitionConfigurer<S, E> withAsyncAction(AsyncAction<S, E> asyncAction);
+
+	/**
+	 * Sets a set of {@link AsyncAction}s to be executed asynchronously after the transition completes.
+	 */
+	ExternalTransitionConfigurer<S, E> withAsyncActions(Set<AsyncAction<S, E>> asyncActions);
 
 }

--- a/src/main/java/alex/band/statemachine/builder/InternalTransitionConfigurer.java
+++ b/src/main/java/alex/band/statemachine/builder/InternalTransitionConfigurer.java
@@ -2,6 +2,7 @@ package alex.band.statemachine.builder;
 
 import java.util.Set;
 
+import alex.band.statemachine.transition.AsyncAction;
 import alex.band.statemachine.transition.Guard;
 import alex.band.statemachine.transition.TransitionAction;
 
@@ -34,5 +35,15 @@ public interface InternalTransitionConfigurer<S, E> {
 	 * Sets a set of {@link TransitionAction}s to be executed during the transition.
 	 */
 	InternalTransitionConfigurer<S, E> withActions(Set<TransitionAction<S, E>> actions);
+
+	/**
+	 * Sets an {@link AsyncAction} to be executed asynchronously after the transition completes.
+	 */
+	InternalTransitionConfigurer<S, E> withAsyncAction(AsyncAction<S, E> asyncAction);
+
+	/**
+	 * Sets a set of {@link AsyncAction}s to be executed asynchronously after the transition completes.
+	 */
+	InternalTransitionConfigurer<S, E> withAsyncActions(Set<AsyncAction<S, E>> asyncActions);
 
 }

--- a/src/main/java/alex/band/statemachine/builder/StateMachineBuilder.java
+++ b/src/main/java/alex/band/statemachine/builder/StateMachineBuilder.java
@@ -1,6 +1,7 @@
 package alex.band.statemachine.builder;
 
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 import alex.band.statemachine.StateMachine;
 import alex.band.statemachine.StateMachineStartAction;
@@ -47,6 +48,12 @@ public interface StateMachineBuilder<S, E> {
 	 * Configures internal {@link Transition} of the {@link StateMachine}.
 	 */
 	InternalTransitionConfigurer<S, E>  defineInternalTransitionFor(S sourceState);
+
+	/**
+	 * Sets the {@link ExecutorService} for executing {@link alex.band.statemachine.transition.AsyncAction}s.
+	 * It must be set, if async actions are configured.
+	 */
+	StateMachineBuilder<S, E> withExecutorService(ExecutorService executorService);
 
 	/**
 	 * Builds the {@link StateMachine} with the given configuration.

--- a/src/main/java/alex/band/statemachine/builder/impl/ExternalTransitionConfigurerImpl.java
+++ b/src/main/java/alex/band/statemachine/builder/impl/ExternalTransitionConfigurerImpl.java
@@ -3,6 +3,7 @@ package alex.band.statemachine.builder.impl;
 import java.util.Set;
 
 import alex.band.statemachine.builder.ExternalTransitionConfigurer;
+import alex.band.statemachine.transition.AsyncAction;
 import alex.band.statemachine.transition.Guard;
 import alex.band.statemachine.transition.Transition;
 import alex.band.statemachine.transition.TransitionAction;
@@ -50,6 +51,18 @@ public class ExternalTransitionConfigurerImpl<S, E> implements ExternalTransitio
 	@Override
 	public ExternalTransitionConfigurer<S, E> withActions(Set<TransitionAction<S, E>> actions) {
 		transition.addActions(actions);
+		return this;
+	}
+
+	@Override
+	public ExternalTransitionConfigurer<S, E> withAsyncAction(AsyncAction<S, E> asyncAction) {
+		transition.addAsyncAction(asyncAction);
+		return this;
+	}
+
+	@Override
+	public ExternalTransitionConfigurer<S, E> withAsyncActions(Set<AsyncAction<S, E>> asyncActions) {
+		transition.addAsyncActions(asyncActions);
 		return this;
 	}
 

--- a/src/main/java/alex/band/statemachine/builder/impl/InternalTransitionConfigurerImpl.java
+++ b/src/main/java/alex/band/statemachine/builder/impl/InternalTransitionConfigurerImpl.java
@@ -3,6 +3,7 @@ package alex.band.statemachine.builder.impl;
 import java.util.Set;
 
 import alex.band.statemachine.builder.InternalTransitionConfigurer;
+import alex.band.statemachine.transition.AsyncAction;
 import alex.band.statemachine.transition.Guard;
 import alex.band.statemachine.transition.Transition;
 import alex.band.statemachine.transition.TransitionAction;
@@ -44,6 +45,18 @@ public class InternalTransitionConfigurerImpl<S, E> implements InternalTransitio
 	@Override
 	public InternalTransitionConfigurer<S, E> withActions(Set<TransitionAction<S, E>> actions) {
 		transition.addActions(actions);
+		return this;
+	}
+
+	@Override
+	public InternalTransitionConfigurer<S, E> withAsyncAction(AsyncAction<S, E> asyncAction) {
+		transition.addAsyncAction(asyncAction);
+		return this;
+	}
+
+	@Override
+	public InternalTransitionConfigurer<S, E> withAsyncActions(Set<AsyncAction<S, E>> asyncActions) {
+		transition.addAsyncActions(asyncActions);
 		return this;
 	}
 

--- a/src/main/java/alex/band/statemachine/builder/impl/StateMachineBuilderImpl.java
+++ b/src/main/java/alex/band/statemachine/builder/impl/StateMachineBuilderImpl.java
@@ -1,11 +1,12 @@
 package alex.band.statemachine.builder.impl;
 
+import static alex.band.statemachine.util.Asserts.checkState;
+
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static alex.band.statemachine.util.Asserts.checkState;
+import java.util.concurrent.ExecutorService;
 
 import alex.band.statemachine.StateMachine;
 import alex.band.statemachine.StateMachineStartAction;
@@ -39,6 +40,7 @@ public class StateMachineBuilderImpl<S, E> implements StateMachineBuilder<S, E> 
 	static final String FINAL_STATE_IS_NOT_DEFINED = "Final State is not defined.";
 	static final String INITIAL_STATE_IS_NOT_DEFINED = "Initial State is not defined.";
 	static final String THERE_ARE_NO_STATES_DEFINED = "There are no States defined.";
+	static final String ASYNC_ACTIONS_WITHOUT_EXECUTOR = "AsyncActions are defined but ExecutorService is not set.";
 
 	private State<S, E> initialState;
 	private State<S, E> finalState;
@@ -46,10 +48,11 @@ public class StateMachineBuilderImpl<S, E> implements StateMachineBuilder<S, E> 
 	private Map<S, Set<Transition<S, E>>> transitions = new HashMap<>();
 	private Set<StateMachineStartAction<S, E>> startActions = new LinkedHashSet<>();
 	private Set<StateMachineStopAction<S, E>> stopActions = new LinkedHashSet<>();
+	private ExecutorService executorService;
 
 	@Override
-	public StartStopActionsConfigurer defineStartStopActions() {
-		StartStopActionsConfigurerImpl  startStopConfigurer = new StartStopActionsConfigurerImpl();
+	public StartStopActionsConfigurer<S, E> defineStartStopActions() {
+		StartStopActionsConfigurerImpl<S, E> startStopConfigurer = new StartStopActionsConfigurerImpl<>();
 		startActions = startStopConfigurer.getStartActions();
 		stopActions = startStopConfigurer.getStopActions();
 		return startStopConfigurer;
@@ -66,7 +69,7 @@ public class StateMachineBuilderImpl<S, E> implements StateMachineBuilder<S, E> 
 	@Override
 	public void defineStates(Set<S> states) {
 		for (S state: states) {
-			addState(new StateImpl<S, E>(state));
+			addState(new StateImpl<>(state));
 		}
 	}
 
@@ -87,10 +90,17 @@ public class StateMachineBuilderImpl<S, E> implements StateMachineBuilder<S, E> 
 	}
 
 	@Override
+	public StateMachineBuilder<S, E> withExecutorService(ExecutorService executorService) {
+		this.executorService = executorService;
+		return this;
+	}
+
+	@Override
 	public StateMachine<S, E> build() {
 		validateStates();
 		validateTransitions();
 		validateTopology();
+		validateAsyncActions();
 		return createStateMachine();
 	}
 
@@ -144,6 +154,19 @@ public class StateMachineBuilderImpl<S, E> implements StateMachineBuilder<S, E> 
 		checkState(exitedStates.isEmpty(), STATES_WITHOUT_OUTBOUND_TRANSITION, exitedStates);
 	}
 
+	private void validateAsyncActions() {
+		if (executorService != null) {
+			return;
+		}
+		for (Set<Transition<S, E>> stateTransitions: transitions.values()) {
+			for (Transition<S, E> transition: stateTransitions) {
+				if (!transition.getAsyncActions().isEmpty()) {
+					checkState(false, ASYNC_ACTIONS_WITHOUT_EXECUTOR);
+				}
+			}
+		}
+	}
+
 	private Set<S> difference(Set<S> set1, Set<S> set2) {
 		Set<S> result = new LinkedHashSet<>(set1);
 		result.removeAll(set2);
@@ -168,6 +191,7 @@ public class StateMachineBuilderImpl<S, E> implements StateMachineBuilder<S, E> 
 		stateMachine.setStartActions(startActions);
 		stateMachine.setStopActions(stopActions);
 		stateMachine.setContext(new StateMachineContextImpl());
+		stateMachine.setExecutorService(executorService);
 
 		return stateMachine;
 	}
@@ -183,7 +207,7 @@ public class StateMachineBuilderImpl<S, E> implements StateMachineBuilder<S, E> 
 
 	private void addTransition(S sourceState, Transition<S, E> transition) {
 		if (!transitions.containsKey(sourceState)) {
-			transitions.put(sourceState, new LinkedHashSet<Transition<S, E>>());
+			transitions.put(sourceState, new LinkedHashSet<>());
 		}
 		transitions.get(sourceState).add(transition);
 	}

--- a/src/main/java/alex/band/statemachine/builder/impl/StateMachineImpl.java
+++ b/src/main/java/alex/band/statemachine/builder/impl/StateMachineImpl.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 import static alex.band.statemachine.util.Asserts.checkState;
 
@@ -15,6 +16,7 @@ import alex.band.statemachine.StateMachineStopAction;
 import alex.band.statemachine.context.StateMachineContext;
 import alex.band.statemachine.message.StateMachineMessage;
 import alex.band.statemachine.state.State;
+import alex.band.statemachine.transition.AsyncAction;
 import alex.band.statemachine.transition.Transition;
 import alex.band.statemachine.transition.TransitionAction;
 
@@ -40,14 +42,15 @@ public class StateMachineImpl<S, E> extends ListenableStateMachine<S, E> {
 
 	private State<S, E> initialState;
 	private State<S, E> finalState;
-	private State<S, E> currentState;
+	private volatile State<S, E> currentState;
 	private Map<S, State<S, E>> states;
 
 	private Set<StateMachineStartAction<S, E>> startActions;
 	private Set<StateMachineStopAction<S, E>> stopActions;
 
-	private boolean running;
+	private volatile boolean running;
 	private StateMachineContext context;
+	private ExecutorService executorService;
 
 	private Queue<StateMachineMessage<E>> deferredQueue = new ArrayDeque<>();
 
@@ -82,7 +85,9 @@ public class StateMachineImpl<S, E> extends ListenableStateMachine<S, E> {
 
 	@Override
 	protected boolean doAccept(StateMachineMessage<E> message) {
-		checkState(running, "Statemachine is not running yet.");
+		if (!running) {
+			return false;
+		}
 
 		if (message == null) {
 			notifyEventNotAccepted(message);
@@ -122,6 +127,7 @@ public class StateMachineImpl<S, E> extends ListenableStateMachine<S, E> {
 			doCurrentStateExit(transition);
 			executeTransitionActions(message, transition.get().getActions());
 			doNewStateEnter(transition, message);
+			executeAsyncActions(message, transition.get().getAsyncActions());
 			return true;
 		}
 
@@ -138,6 +144,15 @@ public class StateMachineImpl<S, E> extends ListenableStateMachine<S, E> {
 	private void executeTransitionActions(StateMachineMessage<E> message, Set<TransitionAction<S, E>> actions) {
 		for (TransitionAction<S, E> action:actions) {
 			action.execute(message, this);
+		}
+	}
+
+	private void executeAsyncActions(StateMachineMessage<E> message, Set<AsyncAction<S, E>> asyncActions) {
+		if (executorService == null || asyncActions.isEmpty()) {
+			return;
+		}
+		for (AsyncAction<S, E> asyncAction : asyncActions) {
+			executorService.submit(() -> asyncAction.execute(message, this));
 		}
 	}
 
@@ -193,6 +208,10 @@ public class StateMachineImpl<S, E> extends ListenableStateMachine<S, E> {
 
 	void setStopActions(Set<StateMachineStopAction<S, E>> stopActions) {
 		this.stopActions = stopActions;
+	}
+
+	void setExecutorService(ExecutorService executorService) {
+		this.executorService = executorService;
 	}
 
 }

--- a/src/main/java/alex/band/statemachine/transition/AsyncAction.java
+++ b/src/main/java/alex/band/statemachine/transition/AsyncAction.java
@@ -1,0 +1,19 @@
+package alex.band.statemachine.transition;
+
+import alex.band.statemachine.StateMachineDetails;
+import alex.band.statemachine.message.StateMachineMessage;
+
+/**
+ * An asynchronous action associated with a {@link Transition} between {@link State} states.
+ * Executed in a separate thread via {@link java.util.concurrent.ExecutorService}.
+ *
+ * @author Aliaksandr Bandarchyk
+ */
+public interface AsyncAction<S, E> {
+
+	/**
+	 * Executes the asynchronous action associated with the transition.
+	 */
+	void execute(StateMachineMessage<E> message, StateMachineDetails<S, E> context);
+
+}

--- a/src/main/java/alex/band/statemachine/transition/Transition.java
+++ b/src/main/java/alex/band/statemachine/transition/Transition.java
@@ -50,6 +50,12 @@ public interface Transition<S, E> {
 	Set<TransitionAction<S, E>> getActions();
 
 	/**
+	 * Returns the set of {@link AsyncAction}s associated with the transition.
+	 * Executed asynchronously after the transition completes.
+	 */
+	Set<AsyncAction<S, E>> getAsyncActions();
+
+	/**
 	 * Returns the transition type: external or internal.
 	 */
 	boolean isExternal();

--- a/src/main/java/alex/band/statemachine/transition/TransitionImpl.java
+++ b/src/main/java/alex/band/statemachine/transition/TransitionImpl.java
@@ -19,6 +19,7 @@ public class TransitionImpl<S, E> implements Transition<S, E> {
 	private E event;
 	private Guard<S, E> guard;
 	private Set<TransitionAction<S, E>> actions = new LinkedHashSet<>();
+	private Set<AsyncAction<S, E>> asyncActions = new LinkedHashSet<>();
 
 	@Override
 	public S getSource() {
@@ -43,6 +44,11 @@ public class TransitionImpl<S, E> implements Transition<S, E> {
 	@Override
 	public Set<TransitionAction<S, E>> getActions() {
 		return Collections.unmodifiableSet(actions);
+	}
+
+	@Override
+	public Set<AsyncAction<S, E>> getAsyncActions() {
+		return Collections.unmodifiableSet(asyncActions);
 	}
 
 	@Override
@@ -77,6 +83,14 @@ public class TransitionImpl<S, E> implements Transition<S, E> {
 
 	public void addActions(Set<TransitionAction<S, E>> actions) {
 		this.actions.addAll(actions);
+	}
+
+	public void addAsyncAction(AsyncAction<S, E> asyncAction) {
+		asyncActions.add(asyncAction);
+	}
+
+	public void addAsyncActions(Set<AsyncAction<S, E>> asyncActions) {
+		this.asyncActions.addAll(asyncActions);
 	}
 
 	public void setExternal(boolean external) {

--- a/src/test/java/alex/band/statemachine/builder/impl/StateMachineAsyncActionTest.java
+++ b/src/test/java/alex/band/statemachine/builder/impl/StateMachineAsyncActionTest.java
@@ -1,0 +1,196 @@
+package alex.band.statemachine.builder.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import alex.band.statemachine.StateMachine;
+
+class StateMachineAsyncActionTest {
+
+	private static final String READY = "Ready";
+	private static final String PROCESSING = "Processing";
+	private static final String STOPPED = "Stopped";
+
+	private static final String START = "Start";
+	private static final String STOP = "Stop";
+
+	private StateMachineBuilderImpl<String, String> builder;
+	private ExecutorService executorService;
+
+	@BeforeEach
+	void setUp() {
+		builder = new StateMachineBuilderImpl<>();
+		executorService = Executors.newCachedThreadPool();
+	}
+
+	@AfterEach
+	void tearDown() {
+		executorService.shutdown();
+	}
+
+	@Test
+	void asyncAction_executedAfterTransition() throws InterruptedException {
+		CountDownLatch latch = new CountDownLatch(1);
+
+		builder.withExecutorService(executorService);
+		builder.defineState(READY).asInitial();
+		builder.defineState(PROCESSING);
+		builder.defineState(STOPPED).asFinal();
+		builder.defineExternalTransitionFor(READY).to(PROCESSING).by(START)
+				.withAsyncAction((msg, ctx) -> latch.countDown());
+		builder.defineExternalTransitionFor(PROCESSING).to(STOPPED).by(STOP);
+
+		StateMachine<String, String> sm = builder.build();
+		sm.start();
+
+		assertTrue(sm.accept(START));
+		assertTrue(latch.await(2, TimeUnit.SECONDS));
+	}
+
+	@Test
+	void asyncAction_executedInSeparateThread() throws InterruptedException {
+		AtomicReference<String> acceptThread = new AtomicReference<>();
+		AtomicReference<String> asyncThread = new AtomicReference<>();
+
+		builder.withExecutorService(executorService);
+		builder.defineState(READY).asInitial();
+		builder.defineState(PROCESSING);
+		builder.defineState(STOPPED).asFinal();
+		builder.defineExternalTransitionFor(READY).to(PROCESSING).by(START)
+				.withAsyncAction((msg, ctx) -> asyncThread.set(Thread.currentThread().getName()));
+		builder.defineExternalTransitionFor(PROCESSING).to(STOPPED).by(STOP);
+
+		StateMachine<String, String> sm = builder.build();
+		sm.start();
+
+		acceptThread.set(Thread.currentThread().getName());
+		sm.accept(START);
+
+		// Allow async action some time to complete
+		Thread.sleep(200);
+
+		assertNotEquals(acceptThread.get(), asyncThread.get(),
+				"Async action should run in a different thread");
+	}
+
+	@Test
+	void asyncAction_doesNotBlockAccept() throws InterruptedException {
+		CountDownLatch asyncStarted = new CountDownLatch(1);
+		CountDownLatch asyncCanFinish = new CountDownLatch(1);
+
+		builder.withExecutorService(executorService);
+		builder.defineState(READY).asInitial();
+		builder.defineState(PROCESSING);
+		builder.defineState(STOPPED).asFinal();
+		builder.defineExternalTransitionFor(READY).to(PROCESSING).by(START)
+				.withAsyncAction((msg, ctx) -> {
+					asyncStarted.countDown();
+					try {
+						asyncCanFinish.await(2, TimeUnit.SECONDS);
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
+				});
+		builder.defineExternalTransitionFor(PROCESSING).to(STOPPED).by(STOP);
+
+		StateMachine<String, String> sm = builder.build();
+		sm.start();
+
+		// accept should return control quickly
+		boolean accepted = sm.accept(START);
+		assertTrue(accepted);
+
+		// State already changed even though async action is still running
+		assertEquals(PROCESSING, sm.getCurrentState().getId());
+
+		// Let async action complete
+		asyncCanFinish.countDown();
+		assertTrue(asyncStarted.await(2, TimeUnit.SECONDS));
+	}
+
+	@Test
+	void asyncAction_receivesCorrectMessageAndContext() throws InterruptedException {
+		AtomicReference<String> receivedEvent = new AtomicReference<>();
+		AtomicReference<String> receivedState = new AtomicReference<>();
+		CountDownLatch latch = new CountDownLatch(1);
+
+		builder.withExecutorService(executorService);
+		builder.defineState(READY).asInitial();
+		builder.defineState(PROCESSING);
+		builder.defineState(STOPPED).asFinal();
+		builder.defineExternalTransitionFor(READY).to(PROCESSING).by(START)
+				.withAsyncAction((msg, ctx) -> {
+					receivedEvent.set(msg.getEvent());
+					receivedState.set(ctx.getCurrentState().getId());
+					latch.countDown();
+				});
+		builder.defineExternalTransitionFor(PROCESSING).to(STOPPED).by(STOP);
+
+		StateMachine<String, String> sm = builder.build();
+		sm.start();
+		sm.accept(START);
+
+		assertTrue(latch.await(2, TimeUnit.SECONDS));
+		assertEquals(START, receivedEvent.get());
+		assertEquals(PROCESSING, receivedState.get());
+	}
+
+	@Test
+	void multipleAsyncActions_allExecuted() throws InterruptedException {
+		CountDownLatch latch = new CountDownLatch(3);
+
+		builder.withExecutorService(executorService);
+		builder.defineState(READY).asInitial();
+		builder.defineState(PROCESSING);
+		builder.defineState(STOPPED).asFinal();
+		builder.defineExternalTransitionFor(READY).to(PROCESSING).by(START)
+				.withAsyncActions(Set.of(
+						(msg, ctx) -> latch.countDown(),
+						(msg, ctx) -> latch.countDown(),
+						(msg, ctx) -> latch.countDown()
+				));
+		builder.defineExternalTransitionFor(PROCESSING).to(STOPPED).by(STOP);
+
+		StateMachine<String, String> sm = builder.build();
+		sm.start();
+		sm.accept(START);
+
+		assertTrue(latch.await(2, TimeUnit.SECONDS));
+	}
+
+	@Test
+	void asyncAction_withInternalTransition() throws InterruptedException {
+		CountDownLatch latch = new CountDownLatch(1);
+
+		builder.withExecutorService(executorService);
+		builder.defineState(READY).asInitial();
+		builder.defineState(PROCESSING);
+		builder.defineState(STOPPED).asFinal();
+		builder.defineExternalTransitionFor(READY).to(PROCESSING).by(START);
+		builder.defineInternalTransitionFor(PROCESSING).by(STOP)
+				.withAsyncAction((msg, ctx) -> latch.countDown());
+		builder.defineExternalTransitionFor(PROCESSING).to(STOPPED).by("Finish");
+
+		StateMachine<String, String> sm = builder.build();
+		sm.start();
+		sm.accept(START);
+		assertEquals(PROCESSING, sm.getCurrentState().getId());
+
+		sm.accept(STOP);
+		assertTrue(latch.await(2, TimeUnit.SECONDS));
+		assertEquals(PROCESSING, sm.getCurrentState().getId());
+	}
+
+}

--- a/src/test/java/alex/band/statemachine/builder/impl/StateMachineBuilderImplTest.java
+++ b/src/test/java/alex/band/statemachine/builder/impl/StateMachineBuilderImplTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.concurrent.Executors;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -193,6 +195,44 @@ class StateMachineBuilderImplTest {
 
 		stateMachine.accept(E1);
 		assertEquals(S3, stateMachine.getCurrentState().getId());
+	}
+
+	@Test
+	void asyncActionsWithoutExecutorServiceIsNotAllowed() {
+		IllegalStateException ex = assertThrows(IllegalStateException.class, () -> {
+			builder.defineState(S1).asInitial();
+			builder.defineState(S2).asFinal();
+			builder.defineExternalTransitionFor(S1).to(S2).by(E1)
+					.withAsyncAction((msg, ctx) -> {});
+			builder.build();
+		});
+		assertTrue(ex.getMessage().contains(StateMachineBuilderImpl.ASYNC_ACTIONS_WITHOUT_EXECUTOR));
+	}
+
+	@Test
+	void asyncActionsWithExecutorServiceIsAllowed() {
+		var executor = Executors.newSingleThreadExecutor();
+		try {
+			builder.withExecutorService(executor);
+			builder.defineState(S1).asInitial();
+			builder.defineState(S2).asFinal();
+			builder.defineExternalTransitionFor(S1).to(S2).by(E1)
+					.withAsyncAction((msg, ctx) -> {});
+			builder.build();
+		} finally {
+			executor.shutdown();
+		}
+	}
+
+	@Test
+	void noAsyncActionsNoExecutorServiceIsAllowed() {
+		builder.defineState(S1).asInitial();
+		builder.defineState(S2).asFinal();
+		builder.defineExternalTransitionFor(S1).to(S2).by(E1);
+		StateMachine<String, String> stateMachine = builder.build();
+		stateMachine.start();
+		assertTrue(stateMachine.accept(E1));
+		assertEquals(S2, stateMachine.getCurrentState().getId());
 	}
 
 	private String withoutPlaceholder(String str) {

--- a/src/test/java/alex/band/statemachine/builder/impl/StateMachineConcurrencyTest.java
+++ b/src/test/java/alex/band/statemachine/builder/impl/StateMachineConcurrencyTest.java
@@ -1,0 +1,196 @@
+package alex.band.statemachine.builder.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import alex.band.statemachine.StateMachine;
+import alex.band.statemachine.listener.StateMachineListenerAdapter;
+
+class StateMachineConcurrencyTest {
+
+	private static final String S1 = "Ready";
+	private static final String S2 = "Processing";
+	private static final String S3 = "Stopped";
+
+	private static final String TRANSITION = "Transition";
+
+	private StateMachineBuilderImpl<String, String> builder;
+	private ExecutorService threadPool;
+
+	@BeforeEach
+	void setUp() {
+		builder = new StateMachineBuilderImpl<>();
+		threadPool = Executors.newCachedThreadPool();
+	}
+
+	@AfterEach
+	void tearDown() {
+		threadPool.shutdown();
+	}
+
+	@Test
+	void concurrentAccept_allTransitionsSerialized() throws Exception {
+		builder.defineState(S1).asInitial();
+		builder.defineState(S2);
+		builder.defineState(S3).asFinal();
+		builder.defineExternalTransitionFor(S1).to(S2).by(TRANSITION);
+		builder.defineExternalTransitionFor(S2).to(S3).by(TRANSITION);
+
+		StateMachine<String, String> sm = builder.build();
+		sm.start();
+
+		int threadCount = 10;
+		CyclicBarrier barrier = new CyclicBarrier(threadCount + 1); // +1 for the main thread
+		List<Boolean> results = Collections.synchronizedList(new java.util.ArrayList<>());
+
+		List<Future<?>> futures = new java.util.ArrayList<>();
+		for (int i = 0; i < threadCount; i++) {
+			futures.add(threadPool.submit(() -> {
+				try {
+					barrier.await(5, TimeUnit.SECONDS);
+				} catch (Exception e) {
+					throw new RuntimeException(e);
+				}
+				results.add(sm.accept(TRANSITION));
+			}));
+		}
+
+		// Main thread synchronizes with workers
+		barrier.await(5, TimeUnit.SECONDS);
+
+		for (Future<?> f : futures) {
+			f.get(5, TimeUnit.SECONDS);
+		}
+
+		// First thread transitions to S2, second to S3 (final)
+		// The rest are rejected
+		long accepted = results.stream().filter(r -> r).count();
+		assertEquals(2, accepted, "Only 2 transitions should succeed (S1→S2, S2→S3)");
+		assertEquals(S3, sm.getCurrentState().getId());
+	}
+
+	@Test
+	void getCurrentState_afterAccept_isDeterministic() throws Exception {
+
+		int iterations = 100;
+		for (int i = 0; i < iterations; i++) {
+			StateMachineBuilderImpl<String, String> b = new StateMachineBuilderImpl<>();
+			b.defineState(S1).asInitial();
+			b.defineState(S2).asFinal();
+			b.defineExternalTransitionFor(S1).to(S2).by(TRANSITION);
+
+			StateMachine<String, String> fsm = b.build();
+			fsm.start();
+
+			boolean result = fsm.accept(TRANSITION);
+
+			if (result) {
+				assertEquals(S2, fsm.getCurrentState().getId(),
+						"getCurrentState should return target state immediately after accept");
+			}
+		}
+	}
+
+	@Test
+	void addListener_duringAccept_doesNotThrow() throws Exception {
+		AtomicBoolean exceptionCaught = new AtomicBoolean(false);
+
+		builder.defineState(S1).asInitial();
+		builder.defineState(S2).asFinal();
+		builder.defineExternalTransitionFor(S1).to(S2).by(TRANSITION);
+
+		StateMachine<String, String> sm = builder.build();
+		sm.start();
+
+		CountDownLatch latch = new CountDownLatch(1);
+
+		Thread acceptThread = new Thread(() -> {
+			try {
+				sm.accept(TRANSITION);
+			} catch (Exception e) {
+				exceptionCaught.set(true);
+			} finally {
+				latch.countDown();
+			}
+		});
+
+		Thread addListenerThread = new Thread(() -> {
+			for (int i = 0; i < 100; i++) {
+				sm.addListener(new StateMachineListenerAdapter<String, String>() {
+				});
+			}
+		});
+
+		acceptThread.start();
+		addListenerThread.start();
+
+		acceptThread.join(5000);
+		addListenerThread.join(5000);
+
+		assertFalse(exceptionCaught.get(), "No exception should be thrown during concurrent addListener");
+	}
+
+	@Test
+	void concurrentStartStop_noRaceCondition() throws InterruptedException {
+		builder.defineState(S1).asInitial();
+		builder.defineState(S2).asFinal();
+		builder.defineExternalTransitionFor(S1).to(S2).by(TRANSITION);
+
+		// Repeatedly create and start/stop FSM from different threads
+		for (int round = 0; round < 10; round++) {
+			StateMachine<String, String> sm = builder.build();
+			CountDownLatch startLatch = new CountDownLatch(1);
+			CountDownLatch stopLatch = new CountDownLatch(1);
+			AtomicBoolean startOk = new AtomicBoolean(false);
+			AtomicBoolean stopOk = new AtomicBoolean(false);
+
+			Thread startThread = new Thread(() -> {
+				try {
+					sm.start();
+					startOk.set(true);
+				} catch (IllegalStateException e) {
+					// already started
+				} finally {
+					startLatch.countDown();
+				}
+			});
+
+			Thread stopThread = new Thread(() -> {
+				try {
+					startLatch.await(2, TimeUnit.SECONDS);
+					sm.stop();
+					stopOk.set(true);
+				} catch (IllegalStateException | InterruptedException e) {
+					// already stopped
+				} finally {
+					stopLatch.countDown();
+				}
+			});
+
+			startThread.start();
+			stopThread.start();
+
+			startThread.join(2000);
+			stopThread.join(2000);
+
+			// At least one operation should succeed
+			assertTrue(startOk.get() || stopOk.get(), "At least one operation should succeed");
+		}
+	}
+
+}

--- a/src/test/java/alex/band/statemachine/builder/impl/StateMachineLifecycleTest.java
+++ b/src/test/java/alex/band/statemachine/builder/impl/StateMachineLifecycleTest.java
@@ -111,10 +111,13 @@ class StateMachineLifecycleTest {
 	}
 
 	@Test
-	void startStop_exceptionShouldBeThrownOnSendingEventToStoppedStateMachine() {
+	void startStop_acceptReturnsFalseWhenStateMachineIsStopped() {
 		stateMachine = buildMachineForStartStopTests();
 
-		assertThrows(IllegalStateException.class, () -> stateMachine.accept(STOP_EVENT));
+		stateMachine.start();
+		stateMachine.stop();
+
+		assertFalse(stateMachine.accept(STOP_EVENT));
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

Replace the previous async FSM model with a **synchronous FSM + optional async actions** architecture.

### Key changes

- **Sync `accept()`** — returns `boolean`, blocking until transition completes
- **Thread safety** — `synchronized` on `accept/start/stop/addListener/removeListener`, `volatile` on `running` and `currentState`
- **AsyncAction interface** — new `AsyncAction<S, E>` for asynchronous transition effects, executed in `ExecutorService`
- **Builder API** — `withAsyncAction()` / `withAsyncActions()` in transition configurers, `withExecutorService()` on builder
- **Validation** — `build()` fails if async actions are defined without an executor
- **No incoming queue** — removed `ArrayBlockingQueue` / worker task model in favor of direct synchronous processing

### Tests

- 3 new validation tests (async actions require executor)
- 6 new async action tests (execution, separate thread, non-blocking, message/context, multiple, internal transition)
- 4 new concurrency tests (serialized accept, deterministic getCurrentState, addListener safety, start/stop races)
- All 76 tests pass