### PR TITLE
feat: SM-20 try-catch in Guard.evaluate()

### DIFF
--- a/src/main/java/alex/band/statemachine/state/StateImpl.java
+++ b/src/main/java/alex/band/statemachine/state/StateImpl.java
@@ -5,6 +5,8 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import alex.band.statemachine.StateMachineDetails;
 import alex.band.statemachine.message.StateMachineMessage;
@@ -16,6 +18,8 @@ import alex.band.statemachine.transition.Transition;
  * @author Aliaksandr Bandarchyk
  */
 public class StateImpl<S, E> implements State<S, E> {
+
+	private static final Logger LOGGER = Logger.getLogger(StateImpl.class.getName());
 
 	private S stateId;
 	private Set<StateAction<S, E>> actions = new LinkedHashSet<>();
@@ -33,7 +37,16 @@ public class StateImpl<S, E> implements State<S, E> {
 		}
 
 		for (Transition<S, E> transition: transitions.get(message.getEvent())) {
-			if (!transition.getGuard().isPresent() || transition.getGuard().get().evaluate(message, context)) {
+			boolean guardPassed;
+			try {
+				guardPassed = !transition.getGuard().isPresent()
+					|| transition.getGuard().get().evaluate(message, context);
+			} catch (Exception e) {
+				// Guard evaluation failed - treat as guard not passed and continue checking other transitions
+				LOGGER.log(Level.WARNING, "Guard evaluation failed for transition in state " + stateId + ", treating as guard not passed", e);
+				guardPassed = false;
+			}
+			if (guardPassed) {
 				return Optional.of(transition);
 			}
 		}

--- a/src/main/java/alex/band/statemachine/transition/GuardsComposer.java
+++ b/src/main/java/alex/band/statemachine/transition/GuardsComposer.java
@@ -1,6 +1,7 @@
 package alex.band.statemachine.transition;
 
-import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import alex.band.statemachine.StateMachineDetails;
 import alex.band.statemachine.message.StateMachineMessage;
@@ -9,7 +10,9 @@ import alex.band.statemachine.message.StateMachineMessage;
  * @author Aliaksandr Bandarchyk
  */
 public class GuardsComposer {
-	
+
+	private static final Logger LOGGER = Logger.getLogger(GuardsComposer.class.getName());
+
 	private GuardsComposer() {
 	}
 	
@@ -34,8 +37,17 @@ public class GuardsComposer {
 
 		@Override
 		public boolean evaluate(StateMachineMessage<E> message, StateMachineDetails<S, E> context) {
-			return Arrays.stream(guards)
-					.allMatch(guard -> guard.evaluate(message, context));
+			for (Guard<S, E> guard : guards) {
+				try {
+					if (!guard.evaluate(message, context)) {
+						return false;
+					}
+				} catch (Exception e) {
+					LOGGER.log(Level.WARNING, "Guard evaluation failed in ConsiderAllGuard, treating as false", e);
+					return false;
+				}
+			}
+			return true;
 		}
 	}
 
@@ -50,8 +62,17 @@ public class GuardsComposer {
 
 		@Override
 		public boolean evaluate(StateMachineMessage<E> message, StateMachineDetails<S, E> context) {
-			return Arrays.stream(guards)
-					.anyMatch(guard -> guard.evaluate(message, context));
+			for (Guard<S, E> guard : guards) {
+				try {
+					if (guard.evaluate(message, context)) {
+						return true;
+					}
+				} catch (Exception e) {
+					LOGGER.log(Level.WARNING, "Guard evaluation failed in ConsiderAnyGuard, treating as false", e);
+					// Continue checking other guards
+				}
+			}
+			return false;
 		}
 
 	}

--- a/src/test/java/alex/band/statemachine/state/StateImplGuardExceptionTest.java
+++ b/src/test/java/alex/band/statemachine/state/StateImplGuardExceptionTest.java
@@ -1,0 +1,154 @@
+package alex.band.statemachine.state;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import alex.band.statemachine.StateMachineDetails;
+import alex.band.statemachine.message.StateMachineMessage;
+import alex.band.statemachine.message.StateMachineMessageImpl;
+import alex.band.statemachine.transition.Guard;
+import alex.band.statemachine.transition.Transition;
+
+@ExtendWith(MockitoExtension.class)
+class StateImplGuardExceptionTest {
+
+	private static final String STATE_ID = "TestState";
+	private static final String EVENT = "TestEvent";
+
+	@Mock
+	private Guard<String, String> guard1;
+	@Mock
+	private Guard<String, String> guard2;
+	@Mock
+	private Guard<String, String> guard3;
+	@Mock
+	private Transition<String, String> transition1;
+	@Mock
+	private Transition<String, String> transition2;
+	@Mock
+	private Transition<String, String> transition3;
+	
+	private final StateMachineMessage<String> message = new StateMachineMessageImpl<>(EVENT);
+	private final StateMachineDetails<String, String> context = mock(StateMachineDetails.class);
+
+	@Test
+	void getSuitableTransition_whenGuardThrowsException_shouldContinueCheckingOtherTransitions() {
+		// Arrange
+		StateImpl<String, String> state = new StateImpl<>(STATE_ID);
+		
+		// Setup transition1 with guard that throws exception
+		when(transition1.getEvent()).thenReturn(EVENT);
+		when(transition1.getGuard()).thenReturn(Optional.of(guard1));
+		when(guard1.evaluate(message, context)).thenThrow(new RuntimeException("Guard1 failed"));
+		
+		// Setup transition2 with guard that returns false
+		when(transition2.getEvent()).thenReturn(EVENT);
+		when(transition2.getGuard()).thenReturn(Optional.of(guard2));
+		when(guard2.evaluate(message, context)).thenReturn(false);
+		
+		// Setup transition3 with guard that returns true
+		when(transition3.getEvent()).thenReturn(EVENT);
+		when(transition3.getGuard()).thenReturn(Optional.of(guard3));
+		when(guard3.evaluate(message, context)).thenReturn(true);
+		
+		state.addTransition(transition1);
+		state.addTransition(transition2);
+		state.addTransition(transition3);
+		
+		// Act
+		Optional<Transition<String, String>> result = state.getSuitableTransition(message, context);
+		
+		// Assert
+		assertTrue(result.isPresent());
+		assertEquals(transition3, result.get());
+		
+		// Verify that all guards were evaluated
+		verify(guard1, times(1)).evaluate(message, context);
+		verify(guard2, times(1)).evaluate(message, context);
+		verify(guard3, times(1)).evaluate(message, context);
+	}
+
+	@Test
+	void getSuitableTransition_whenAllGuardsThrowException_shouldReturnEmpty() {
+		// Arrange
+		StateImpl<String, String> state = new StateImpl<>(STATE_ID);
+		
+		// Setup all transitions with guards that throw exceptions
+		when(transition1.getEvent()).thenReturn(EVENT);
+		when(transition1.getGuard()).thenReturn(Optional.of(guard1));
+		when(guard1.evaluate(message, context)).thenThrow(new RuntimeException("Guard1 failed"));
+		
+		when(transition2.getEvent()).thenReturn(EVENT);
+		when(transition2.getGuard()).thenReturn(Optional.of(guard2));
+		when(guard2.evaluate(message, context)).thenThrow(new RuntimeException("Guard2 failed"));
+		
+		state.addTransition(transition1);
+		state.addTransition(transition2);
+		
+		// Act
+		Optional<Transition<String, String>> result = state.getSuitableTransition(message, context);
+		
+		// Assert
+		assertFalse(result.isPresent());
+		
+		// Verify that all guards were evaluated
+		verify(guard1, times(1)).evaluate(message, context);
+		verify(guard2, times(1)).evaluate(message, context);
+	}
+
+	@Test
+	void getSuitableTransition_whenFirstGuardThrowsAndSecondPasses_shouldReturnSecondTransition() {
+		// Arrange
+		StateImpl<String, String> state = new StateImpl<>(STATE_ID);
+		
+		// Setup transition1 with guard that throws exception
+		when(transition1.getEvent()).thenReturn(EVENT);
+		when(transition1.getGuard()).thenReturn(Optional.of(guard1));
+		when(guard1.evaluate(message, context)).thenThrow(new RuntimeException("Guard1 failed"));
+		
+		// Setup transition2 with guard that returns true
+		when(transition2.getEvent()).thenReturn(EVENT);
+		when(transition2.getGuard()).thenReturn(Optional.of(guard2));
+		when(guard2.evaluate(message, context)).thenReturn(true);
+		
+		state.addTransition(transition1);
+		state.addTransition(transition2);
+		
+		// Act
+		Optional<Transition<String, String>> result = state.getSuitableTransition(message, context);
+		
+		// Assert
+		assertTrue(result.isPresent());
+		assertEquals(transition2, result.get());
+		
+		// Verify that both guards were evaluated
+		verify(guard1, times(1)).evaluate(message, context);
+		verify(guard2, times(1)).evaluate(message, context);
+	}
+
+	@Test
+	void getSuitableTransition_whenTransitionWithoutGuard_shouldReturnTransition() {
+		// Arrange
+		StateImpl<String, String> state = new StateImpl<>(STATE_ID);
+		
+		// Setup transition without guard
+		when(transition1.getEvent()).thenReturn(EVENT);
+		when(transition1.getGuard()).thenReturn(Optional.empty());
+		
+		state.addTransition(transition1);
+		
+		// Act
+		Optional<Transition<String, String>> result = state.getSuitableTransition(message, context);
+		
+		// Assert
+		assertTrue(result.isPresent());
+		assertEquals(transition1, result.get());
+	}
+}

--- a/src/test/java/alex/band/statemachine/transition/GuardsComposerExceptionTest.java
+++ b/src/test/java/alex/band/statemachine/transition/GuardsComposerExceptionTest.java
@@ -1,0 +1,203 @@
+package alex.band.statemachine.transition;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import alex.band.statemachine.StateMachineDetails;
+import alex.band.statemachine.message.StateMachineMessage;
+import alex.band.statemachine.message.StateMachineMessageImpl;
+
+@ExtendWith(MockitoExtension.class)
+class GuardsComposerExceptionTest {
+
+	private static final String EVENT = "TestEvent";
+
+	@Mock
+	private Guard<String, String> guard1;
+	@Mock
+	private Guard<String, String> guard2;
+	@Mock
+	private Guard<String, String> guard3;
+
+	private final StateMachineMessage<String> message = new StateMachineMessageImpl<>(EVENT);
+	private final StateMachineDetails<String, String> context = mock(StateMachineDetails.class);
+
+	@Test
+	void considerAll_whenGuardThrowsException_shouldReturnFalse() {
+		// Arrange
+		when(guard1.evaluate(message, context)).thenReturn(true);
+		when(guard2.evaluate(message, context)).thenThrow(new RuntimeException("Guard2 failed"));
+		
+		// Act
+		Guard<String, String> composed = GuardsComposer.considerAll(guard1, guard2, guard3);
+		boolean result = composed.evaluate(message, context);
+		
+		// Assert
+		assertFalse(result);
+		
+		// Verify that guards were evaluated until the exception
+		verify(guard1, times(1)).evaluate(message, context);
+		verify(guard2, times(1)).evaluate(message, context);
+		verify(guard3, never()).evaluate(message, context);
+	}
+
+	@Test
+	void considerAll_whenFirstGuardThrowsException_shouldReturnFalse() {
+		// Arrange
+		when(guard1.evaluate(message, context)).thenThrow(new RuntimeException("Guard1 failed"));
+		
+		// Act
+		Guard<String, String> composed = GuardsComposer.considerAll(guard1, guard2, guard3);
+		boolean result = composed.evaluate(message, context);
+		
+		// Assert
+		assertFalse(result);
+		
+		// Verify that only first guard was evaluated
+		verify(guard1, times(1)).evaluate(message, context);
+		verify(guard2, never()).evaluate(message, context);
+		verify(guard3, never()).evaluate(message, context);
+	}
+
+	@Test
+	void considerAll_whenAllGuardsReturnTrue_shouldReturnTrue() {
+		// Arrange
+		when(guard1.evaluate(message, context)).thenReturn(true);
+		when(guard2.evaluate(message, context)).thenReturn(true);
+		when(guard3.evaluate(message, context)).thenReturn(true);
+		
+		// Act
+		Guard<String, String> composed = GuardsComposer.considerAll(guard1, guard2, guard3);
+		boolean result = composed.evaluate(message, context);
+		
+		// Assert
+		assertTrue(result);
+		
+		// Verify that all guards were evaluated
+		verify(guard1, times(1)).evaluate(message, context);
+		verify(guard2, times(1)).evaluate(message, context);
+		verify(guard3, times(1)).evaluate(message, context);
+	}
+
+	@Test
+	void considerAll_whenSecondGuardReturnsFalse_shouldReturnFalseWithoutEvaluatingThird() {
+		// Arrange
+		when(guard1.evaluate(message, context)).thenReturn(true);
+		when(guard2.evaluate(message, context)).thenReturn(false);
+		
+		// Act
+		Guard<String, String> composed = GuardsComposer.considerAll(guard1, guard2, guard3);
+		boolean result = composed.evaluate(message, context);
+		
+		// Assert
+		assertFalse(result);
+		
+		// Verify that only first two guards were evaluated
+		verify(guard1, times(1)).evaluate(message, context);
+		verify(guard2, times(1)).evaluate(message, context);
+		verify(guard3, never()).evaluate(message, context);
+	}
+
+	@Test
+	void considerAny_whenGuardThrowsException_shouldContinueCheckingOtherGuards() {
+		// Arrange
+		when(guard1.evaluate(message, context)).thenReturn(false);
+		when(guard2.evaluate(message, context)).thenThrow(new RuntimeException("Guard2 failed"));
+		when(guard3.evaluate(message, context)).thenReturn(true);
+		
+		// Act
+		Guard<String, String> composed = GuardsComposer.considerAny(guard1, guard2, guard3);
+		boolean result = composed.evaluate(message, context);
+		
+		// Assert
+		assertTrue(result);
+		
+		// Verify that all guards were evaluated
+		verify(guard1, times(1)).evaluate(message, context);
+		verify(guard2, times(1)).evaluate(message, context);
+		verify(guard3, times(1)).evaluate(message, context);
+	}
+
+	@Test
+	void considerAny_whenAllGuardsThrowException_shouldReturnFalse() {
+		// Arrange
+		when(guard1.evaluate(message, context)).thenThrow(new RuntimeException("Guard1 failed"));
+		when(guard2.evaluate(message, context)).thenThrow(new RuntimeException("Guard2 failed"));
+		when(guard3.evaluate(message, context)).thenThrow(new RuntimeException("Guard3 failed"));
+		
+		// Act
+		Guard<String, String> composed = GuardsComposer.considerAny(guard1, guard2, guard3);
+		boolean result = composed.evaluate(message, context);
+		
+		// Assert
+		assertFalse(result);
+		
+		// Verify that all guards were evaluated
+		verify(guard1, times(1)).evaluate(message, context);
+		verify(guard2, times(1)).evaluate(message, context);
+		verify(guard3, times(1)).evaluate(message, context);
+	}
+
+	@Test
+	void considerAny_whenFirstGuardReturnsTrue_shouldReturnTrueWithoutEvaluatingOthers() {
+		// Arrange
+		when(guard1.evaluate(message, context)).thenReturn(true);
+		
+		// Act
+		Guard<String, String> composed = GuardsComposer.considerAny(guard1, guard2, guard3);
+		boolean result = composed.evaluate(message, context);
+		
+		// Assert
+		assertTrue(result);
+		
+		// Verify that only first guard was evaluated
+		verify(guard1, times(1)).evaluate(message, context);
+		verify(guard2, never()).evaluate(message, context);
+		verify(guard3, never()).evaluate(message, context);
+	}
+
+	@Test
+	void considerAny_whenSecondGuardThrowsAndThirdReturnsTrue_shouldReturnTrue() {
+		// Arrange
+		when(guard1.evaluate(message, context)).thenReturn(false);
+		when(guard2.evaluate(message, context)).thenThrow(new RuntimeException("Guard2 failed"));
+		when(guard3.evaluate(message, context)).thenReturn(true);
+		
+		// Act
+		Guard<String, String> composed = GuardsComposer.considerAny(guard1, guard2, guard3);
+		boolean result = composed.evaluate(message, context);
+		
+		// Assert
+		assertTrue(result);
+		
+		// Verify that all guards were evaluated
+		verify(guard1, times(1)).evaluate(message, context);
+		verify(guard2, times(1)).evaluate(message, context);
+		verify(guard3, times(1)).evaluate(message, context);
+	}
+
+	@Test
+	void considerAny_whenAllGuardsReturnFalse_shouldReturnFalse() {
+		// Arrange
+		when(guard1.evaluate(message, context)).thenReturn(false);
+		when(guard2.evaluate(message, context)).thenReturn(false);
+		when(guard3.evaluate(message, context)).thenReturn(false);
+		
+		// Act
+		Guard<String, String> composed = GuardsComposer.considerAny(guard1, guard2, guard3);
+		boolean result = composed.evaluate(message, context);
+		
+		// Assert
+		assertFalse(result);
+		
+		// Verify that all guards were evaluated
+		verify(guard1, times(1)).evaluate(message, context);
+		verify(guard2, times(1)).evaluate(message, context);
+		verify(guard3, times(1)).evaluate(message, context);
+	}
+}


### PR DESCRIPTION
Wrap Guard.evaluate() calls in try-catch to prevent state machine disruption when guards throw exceptions. Treat failed guard evaluation as false and continue checking other transitions. Log warnings with stack trace for debugging.

Apply same protection to considerAll() and considerAny() in GuardsComposer. Replace Stream API with explicit for-loops for precise try-catch placement.

Add comprehensive unit tests:
- StateImplGuardExceptionTest: 4 tests for transition guard exception handling
- GuardsComposerExceptionTest: 8 tests for composer exception behavior

Uses java.util.logging to maintain zero-production-dependencies principle.